### PR TITLE
replace letsencrypt git repo with certbot

### DIFF
--- a/manifest.jps
+++ b/manifest.jps
@@ -28,19 +28,19 @@
       ]
     },
     "version": "1.2",
-    "homepage": "https://github.com/jelastic-jps/lets-encrypt",
-    "logo": "https://raw.githubusercontent.com/jelastic-jps/lets-encrypt/master/images/lets-encrypt.png",
+    "homepage": "https://github.com/bubbl/lets-encrypt",
+    "logo": "https://raw.githubusercontent.com/bubbl/lets-encrypt/master/images/lets-encrypt.png",
     "description": {
-      "text": "<span><b>Let's Encrypt</b> is a free and open Certificate Authority (CA), aimed to simplify and automate processes of browser-trusted SSL certificates issuing and appliance.</span><div>The list of currently supported stacks can be found at <a href='https://github.com/jelastic-jps/lets-encrypt#ssl-configuration-with-jelastic-lets-encrypt-add-on' target='_blank' style='color:#75bd4f'>the link</a>.</div><div class='warning-lower' style='color:#b7c3da'><b>Note:</b> Public IP address will be automatically attached to all nodes within the entry point layer (application server or load balancer).</div>",
+      "text": "<span><b>Let's Encrypt</b> is a free and open Certificate Authority (CA), aimed to simplify and automate processes of browser-trusted SSL certificates issuing and appliance.</span><div>The list of currently supported stacks can be found at <a href='https://github.com/bubbl/lets-encrypt#ssl-configuration-with-jelastic-lets-encrypt-add-on' target='_blank' style='color:#75bd4f'>the link</a>.</div><div class='warning-lower' style='color:#b7c3da'><b>Note:</b> Public IP address will be automatically attached to all nodes within the entry point layer (application server or load balancer).</div>",
       "short": "Free tool to configure support of secured SSL connection for an environment, by either internal or custom domain name."
     },
     "onInstall": [
       {
         "execScript": {
           "type": "js",
-          "script": "https://raw.githubusercontent.com/jelastic-jps/lets-encrypt/master/scripts/create-installation-script.js",
+          "script": "https://raw.githubusercontent.com/bubbl/lets-encrypt/master/scripts/create-installation-script.js",
           "params": {
-            "baseDir": "https://raw.githubusercontent.com/jelastic-jps/lets-encrypt/master/scripts",
+            "baseDir": "https://raw.githubusercontent.com/bubbl/lets-encrypt/master/scripts",
             "cronTime": "0 3 * * * *"
           }
         }
@@ -109,7 +109,7 @@
       ]
     },
     "success": {
-      "text": "Your Let’s Encrypt SSL certificate will remain valid for 90 days. One month before expiration the system will automatically request the certificate update, whilst you'll get the appropriate email notification.<br><br>To perform this operation manually at any time, use the <b>Update</b> option at add-on’s panel.<br><br><div>Useful links:</div><div><a href='https://github.com/jelastic-jps/lets-encrypt#how-to-renew-ssl-certificate' target='_blank'>How to renew SSL certificate</div><div><a href='https://docs.jelastic.com/custom-domain-via-cname'target='_blank'>How to bind custom domain via CNAME</a></div><div><a href='https://docs.jelastic.com/custom-domain-via-arecord' target='_blank'>How to bind custom domain via A Record</a></div>"
+      "text": "Your Let’s Encrypt SSL certificate will remain valid for 90 days. One month before expiration the system will automatically request the certificate update, whilst you'll get the appropriate email notification.<br><br>To perform this operation manually at any time, use the <b>Update</b> option at add-on’s panel.<br><br><div>Useful links:</div><div><a href='https://github.com/bubbl/lets-encrypt#how-to-renew-ssl-certificate' target='_blank'>How to renew SSL certificate</div><div><a href='https://docs.jelastic.com/custom-domain-via-cname'target='_blank'>How to bind custom domain via CNAME</a></div><div><a href='https://docs.jelastic.com/custom-domain-via-arecord' target='_blank'>How to bind custom domain via A Record</a></div>"
     }
   }
 }

--- a/manifest.jps
+++ b/manifest.jps
@@ -28,19 +28,19 @@
       ]
     },
     "version": "1.2",
-    "homepage": "https://github.com/bubbl/lets-encrypt",
-    "logo": "https://raw.githubusercontent.com/bubbl/lets-encrypt/master/images/lets-encrypt.png",
+    "homepage": "https://github.com/jelastic-jps/lets-encrypt",
+    "logo": "https://raw.githubusercontent.com/jelastic-jps/lets-encrypt/master/images/lets-encrypt.png",
     "description": {
-      "text": "<span><b>Let's Encrypt</b> is a free and open Certificate Authority (CA), aimed to simplify and automate processes of browser-trusted SSL certificates issuing and appliance.</span><div>The list of currently supported stacks can be found at <a href='https://github.com/bubbl/lets-encrypt#ssl-configuration-with-jelastic-lets-encrypt-add-on' target='_blank' style='color:#75bd4f'>the link</a>.</div><div class='warning-lower' style='color:#b7c3da'><b>Note:</b> Public IP address will be automatically attached to all nodes within the entry point layer (application server or load balancer).</div>",
+      "text": "<span><b>Let's Encrypt</b> is a free and open Certificate Authority (CA), aimed to simplify and automate processes of browser-trusted SSL certificates issuing and appliance.</span><div>The list of currently supported stacks can be found at <a href='https://github.com/jelastic-jps/lets-encrypt#ssl-configuration-with-jelastic-lets-encrypt-add-on' target='_blank' style='color:#75bd4f'>the link</a>.</div><div class='warning-lower' style='color:#b7c3da'><b>Note:</b> Public IP address will be automatically attached to all nodes within the entry point layer (application server or load balancer).</div>",
       "short": "Free tool to configure support of secured SSL connection for an environment, by either internal or custom domain name."
     },
     "onInstall": [
       {
         "execScript": {
           "type": "js",
-          "script": "https://raw.githubusercontent.com/bubbl/lets-encrypt/master/scripts/create-installation-script.js",
+          "script": "https://raw.githubusercontent.com/jelastic-jps/lets-encrypt/master/scripts/create-installation-script.js",
           "params": {
-            "baseDir": "https://raw.githubusercontent.com/bubbl/lets-encrypt/master/scripts",
+            "baseDir": "https://raw.githubusercontent.com/jelastic-jps/lets-encrypt/master/scripts",
             "cronTime": "0 3 * * * *"
           }
         }
@@ -109,7 +109,7 @@
       ]
     },
     "success": {
-      "text": "Your Let’s Encrypt SSL certificate will remain valid for 90 days. One month before expiration the system will automatically request the certificate update, whilst you'll get the appropriate email notification.<br><br>To perform this operation manually at any time, use the <b>Update</b> option at add-on’s panel.<br><br><div>Useful links:</div><div><a href='https://github.com/bubbl/lets-encrypt#how-to-renew-ssl-certificate' target='_blank'>How to renew SSL certificate</div><div><a href='https://docs.jelastic.com/custom-domain-via-cname'target='_blank'>How to bind custom domain via CNAME</a></div><div><a href='https://docs.jelastic.com/custom-domain-via-arecord' target='_blank'>How to bind custom domain via A Record</a></div>"
+      "text": "Your Let’s Encrypt SSL certificate will remain valid for 90 days. One month before expiration the system will automatically request the certificate update, whilst you'll get the appropriate email notification.<br><br>To perform this operation manually at any time, use the <b>Update</b> option at add-on’s panel.<br><br><div>Useful links:</div><div><a href='https://github.com/jelastic-jps/lets-encrypt#how-to-renew-ssl-certificate' target='_blank'>How to renew SSL certificate</div><div><a href='https://docs.jelastic.com/custom-domain-via-cname'target='_blank'>How to bind custom domain via CNAME</a></div><div><a href='https://docs.jelastic.com/custom-domain-via-arecord' target='_blank'>How to bind custom domain via A Record</a></div>"
     }
   }
 }

--- a/scripts/generate-ssl-cert.sh
+++ b/scripts/generate-ssl-cert.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+[ -f '/root/letsencrypt_settings'  ] && source '/root/letsencrypt_settings' || echo "No settings available"
+
 iptables -I INPUT -p tcp -m tcp --dport 9999 -j ACCEPT
 iptables -t nat -I PREROUTING -p tcp -m tcp --dport 443 -j REDIRECT --to-ports 9999
 

--- a/scripts/generate-ssl-cert.sh
+++ b/scripts/generate-ssl-cert.sh
@@ -1,14 +1,5 @@
 #!/bin/bash
 
-[ -f '/opt/letsencrypt/settings'  ] && source '/opt/letsencrypt/settings' || echo "No settings available"
-
-#To be sure that r/w access
-mkdir -p /etc/letsencrypt/
-#chown -R jelastic:jelastic /etc/letsencrypt/
-
-cd /opt/letsencrypt
-git pull origin master
-
 iptables -I INPUT -p tcp -m tcp --dport 9999 -j ACCEPT
 iptables -t nat -I PREROUTING -p tcp -m tcp --dport 443 -j REDIRECT --to-ports 9999
 
@@ -17,7 +8,7 @@ test_params='';
 [ "$test" == "true" ] && { test_params='--test-cert --break-my-certs '; }
 
 #Request for certificates
-/opt/letsencrypt/letsencrypt-auto certonly --standalone $test_params --domain $domain --preferred-challenges tls-sni-01 --tls-sni-01-port 9999 --renew-by-default --email $email --agree-tos
+certbot certonly --standalone $test_params --domain $domain --preferred-challenges tls-sni-01 --tls-sni-01-port 9999 --renew-by-default --email $email --agree-tos
 
 iptables -t nat -D PREROUTING -p tcp -m tcp --dport 443 -j REDIRECT --to-ports 9999
 iptables -D INPUT -p tcp -m tcp --dport 9999 -j ACCEPT
@@ -41,8 +32,3 @@ echo $uploadresult | awk -F '{"file":"' '{print $3}' | awk -F ":\"" '{print $1}'
 echo $uploadresult | awk -F '{"file":"' '{print $4}' | awk -F ":\"" '{print $1}' | sed 's/","name"//g' > /tmp/cert.url
 
 sed -i '/^\s*$/d' /tmp/*.url
-
-#installing ssl cert via JEM
-#sed -i '/function doDownloadKeys/a return 0;#letsenctemp' /usr/lib/jelastic/modules/keystore.module
-#jem ssl install
-#sed -i  '/letsenctemp/d' /usr/lib/jelastic/modules/keystore.module

--- a/scripts/install-le.sh
+++ b/scripts/install-le.sh
@@ -1,14 +1,9 @@
 #!/bin/bash
 
 echo Install opel-release
-yum -y install epel-release git bc;
+yum -y install epel-release;
 
-rpm -ivh https://downloads.hpdd.intel.com/public/e2fsprogs/1.42.12.wc1/el7/RPMS/x86_64/libcom_err-devel-1.42.12.wc1-4.el7.centos.x86_64.rpm;
-
-git clone https://github.com/letsencrypt/letsencrypt /opt/letsencrypt;
-
-/opt/letsencrypt/letsencrypt-auto --os-packages-only
-
+yum install -y certbot
 
 JEM_SSL_MODULE_LATEST_URL="https://raw.githubusercontent.com/jelastic/jem/master/usr/lib/jelastic/modules/ssl.module"
 JEM_SSL_MODULE_PATH="/usr/lib/jelastic/modules/ssl.module"

--- a/scripts/install-le.sh
+++ b/scripts/install-le.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 
 echo Install opel-release
-yum -y install epel-release;
-
-yum install -y certbot
+if ! rpm -qa | grep -qw epel-release; then
+    yum -y install epel-release;
+fi
+if ! rpm -qa | grep -qw certbot; then
+    yum install -y certbot
+fi
 
 JEM_SSL_MODULE_LATEST_URL="https://raw.githubusercontent.com/jelastic/jem/master/usr/lib/jelastic/modules/ssl.module"
 JEM_SSL_MODULE_PATH="/usr/lib/jelastic/modules/ssl.module"

--- a/scripts/install-ssl.js
+++ b/scripts/install-ssl.js
@@ -69,7 +69,7 @@ debug.push(resp);
 
 //write configs for ssl generation
 var primaryDomain = window.location.host;
-execParams = '\"domain=\'' + (customDomain || envDomain) + '\'\nemail=\''+email+'\'\nappid=\''+envAppid+'\'\nappdomain=\''+envDomain+'\'\ntest=\''+ (customDomain ? false : true)+  '\'\nprimarydomain=\''+primaryDomain +  '\'\n\" >  /opt/letsencrypt/settings' 
+execParams = '\"domain=\'' + (customDomain || envDomain) + '\'\nemail=\''+email+'\'\nappid=\''+envAppid+'\'\nappdomain=\''+envDomain+'\'\ntest=\''+ (customDomain ? false : true)+  '\'\nprimarydomain=\''+primaryDomain +  '\'\n\" >  /root/letsencrypt_settings' 
 resp = ExecCmdById("printf", execParams); 
 debug.push(resp);
 


### PR DESCRIPTION
I've replaced letsencrypt git repo with centos certbot.

Handles installation better and does not trigger unnecesary updates of main system packages, see #9 