### PR TITLE
Various fixes for ipv6 and auto-update

### DIFF
--- a/scripts/auto-update-ssl-cert.sh
+++ b/scripts/auto-update-ssl-cert.sh
@@ -10,6 +10,8 @@ GIT=$(which git);
 BASE_REPO_URL="https://github.com/jelastic-jps/lets-encrypt"
 RAW_REPO_SCRIPS_URL="https://raw.githubusercontent.com/jelastic-jps/lets-encrypt/master/scripts/"
 
+[[ -z "$WGET" || -z "$OPENSSL" || -z "$GREP" || -z "$SED" || -z "$GIT" ]] && { echo "PATH not set with neccessary commands"; exit 3 ; }
+
 [ -f "${DIR}/opt/letsencrypt/settings"  ] && source "${DIR}/opt/letsencrypt/settings" || { echo "No settings available" ; exit 3 ; }
 [ -f "${DIR}/root/validation.sh"  ] && source "${DIR}/root/validation.sh" || { echo "No validation library available" ; exit 3 ; }
 

--- a/scripts/generate-ssl-cert.sh
+++ b/scripts/generate-ssl-cert.sh
@@ -29,13 +29,17 @@ killall -9 letsencrypt > /dev/null 2>&1
 mkdir -p $DIR/var/log/letsencrypt
 
 iptables -I INPUT -p tcp -m tcp --dport 12345 -j ACCEPT
+ip6tables -I INPUT -p tcp -m tcp --dport 12345 -j ACCEPT
 iptables -t nat -I PREROUTING -p tcp -m tcp --dport 80 -j REDIRECT --to-ports 12345
+ip6tables -t nat -I PREROUTING -p tcp -m tcp --dport 80 -j REDIRECT --to-ports 12345
 
 #Request for certificates
 $DIR/opt/letsencrypt/letsencrypt-auto certonly --standalone $test_params --domain $domain --preferred-challenges http-01 --http-01-port 12345 --renew-by-default --email $email --agree-tos --logs-dir $DIR/var/log/letsencrypt
 
 iptables -t nat -D PREROUTING -p tcp -m tcp --dport 80 -j REDIRECT --to-ports 12345
+ip6tables -t nat -D PREROUTING -p tcp -m tcp --dport 80 -j REDIRECT --to-ports 12345
 iptables -D INPUT -p tcp -m tcp --dport 12345 -j ACCEPT
+ip6tables -D INPUT -p tcp -m tcp --dport 12345 -j ACCEPT
 
 #To be sure that r/w access
 mkdir -p /tmp/

--- a/scripts/ssl-manager.js
+++ b/scripts/ssl-manager.js
@@ -129,13 +129,13 @@ function SSLManager(config) {
             if (!session && me.hasValidToken()) {
                 session = signature;
             }
-            
+
             resp = nodeManager.getEnvInfo();
-            
+
             if (resp.result == 0) {
                 resp = log("checkPermissions");
             }
-            
+
             if (resp && resp.result != 0) {
                 return me.checkEnvAccessAndUpdate(resp);
             }
@@ -321,7 +321,7 @@ function SSLManager(config) {
             resp = jelastic.dev.scripting.CreateScript(scriptName, "js", scriptBody);
 
             java.lang.Thread.sleep(1000);
-            
+
             //build script to avoid caching
             jelastic.dev.scripting.Build(scriptName);
         } catch (ex) {
@@ -495,7 +495,7 @@ function SSLManager(config) {
             "wget --no-check-certificate '%(url)' -O %(scriptPath)",
             "chmod +x %(scriptPath)",
             "crontab -l  >/dev/null | grep -v '%(scriptPath)' | crontab -",
-            "echo \"%(cronTime) su - root -c '%(scriptPath) \\'%(autoUpdateUrl)\\' >> %(log)\"' >> /var/spool/cron/root"
+            "echo \"%(cronTime) su - root -c \\\"%(scriptPath) '%(autoUpdateUrl)' >> %(log)\\\"\" >> /var/spool/cron/root"
         ], {
             url : scriptUrl,
             cronTime : config.cronTime,
@@ -506,8 +506,8 @@ function SSLManager(config) {
 
     me.deploy = function deploy() {
         if (config.deployHook) {
-            return me.exec(me.cmd, "/bin/bash %(hook) >> %(log)", { 
-                hook : config.deployHook, 
+            return me.exec(me.cmd, "/bin/bash %(hook) >> %(log)", {
+                hook : config.deployHook,
                 nodeGroup: config.nodeGroup
             });
         }
@@ -521,9 +521,9 @@ function SSLManager(config) {
 
     me.undeploy = function undeploy() {
         if (config.undeployHook) {
-            return me.exec(me.cmd, "/bin/bash %(hook) >> %(log)", { 
-                hook : config.undeployHook, 
-                nodeGroup: config.nodeGroup 
+            return me.exec(me.cmd, "/bin/bash %(hook) >> %(log)", {
+                hook : config.undeployHook,
+                nodeGroup: config.nodeGroup
             });
         }
 
@@ -846,7 +846,7 @@ function SSLManager(config) {
         if (jelastic.marketplace && jelastic.marketplace.console) {
             return jelastic.marketplace.console.WriteLog(appid, session, message);
         }
-        
+
         return { result : 0 };
     }
 }

--- a/scripts/ssl-manager.js
+++ b/scripts/ssl-manager.js
@@ -495,7 +495,7 @@ function SSLManager(config) {
             "wget --no-check-certificate '%(url)' -O %(scriptPath)",
             "chmod +x %(scriptPath)",
             "crontab -l  >/dev/null | grep -v '%(scriptPath)' | crontab -",
-            "echo \"%(cronTime) %(scriptPath) '%(autoUpdateUrl)' >> %(log)\" >> /var/spool/cron/root"
+            "echo \"%(cronTime) su - root -c '%(scriptPath) \\'%(autoUpdateUrl)\\' >> %(log)\"' >> /var/spool/cron/root"
         ], {
             url : scriptUrl,
             cronTime : config.cronTime,

--- a/scripts/validation.sh
+++ b/scripts/validation.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
 IP=$(which ip)
+[[ -z "$IP" ]] && { echo "ip command not found, unable to verify IP"; exit 3 ; }
+
 EXT_IPs=$($IP a | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p')
+EXT_IPs_v6=$($IP a | sed -En 's/inet6 ::1\/128//;s/.*inet6 (addr:?)?([0-9a-f:]+)\/.*/\2/p')
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/..";
 
 function isLANIP() {
@@ -16,11 +19,29 @@ function isLANIP() {
     return 1
 }
 
+function isLANIPv6() {
+    : ${1:?"Missing param: IP"};
+    local ip
+    local pip=${1}
+    OIFS=$IFS;IFS=':';ip=(${pip});IFS=$OIFS
+    [[ ${ip[0]} == "fc00" ]] && return 0;
+    [[ ${ip[0]} == "fe80" ]] && return 0;
+    [[ ${ip[0]} == "ff0[0-9a-f]" ]] && return 0;
+    [[ ${ip[0]} == "2002" ]] && return 0;
+    [[ ${ip[0]} == "2001" && ${ip[1]} == "db8" ]] && return 0;
+    return 1
+}
+
 function validateExtIP(){
     for EXT_IP in $EXT_IPs
     do
-            isLANIP $EXT_IP || return 0;
+            isLANIP $EXT_IP || HAS_EXTERNAL_v4=0;
     done
+    for EXT_IP in $EXT_IPs_v6
+    do
+            isLANIPv6 $EXT_IP || HAS_EXTERNAL_v6=0;
+    done
+    [[ $HAS_EXTERNAL_v4 -eq 0 || $HAS_EXTERNAL_v6 -eq 0 ]] && return 0;
     { echo "Error: External IP is required!"; exit 1; }
 }
 
@@ -39,9 +60,13 @@ function validateDNSSettings(){
             do
                 dig +short @8.8.8.8 A $single_domain | grep -q $EXT_IP && detected=true;
             done
+            for EXT_IP in $EXT_IPs_v6
+            do
+                dig +short @8.8.8.8 AAAA $single_domain | grep -q $EXT_IP && detected=true;
+            done
 	    [[ $detected == 'false'  ]] && { echo "Error: Incorrect DNS settings for domain $single_domain! It should be bound to containers Public IP."; exit 1 ; };
         done
-	    return 0;
+        return 0;
 }
 
 function validateCertBot(){


### PR DESCRIPTION
I have made some extra validation checks to ensure that the commands used is actually on PATH before execution (before this patch, the auto-updater when executed by cron exits because it can not find the command ip used for validation).

The installation is patched with a new command line for the cron auto-update script to ensure that it will execute as intended with roots full environment variables.

I have added ip6table rules to the generate-ssl-cert.sh script to ensure successful validation when a container have ipv6 enabled. There is also some extra IPv6 checks in the validation script.

All changes are tested and verified.