### PR TITLE
Fix for customssl validation for varnish containers

### DIFF
--- a/scripts/validation.sh
+++ b/scripts/validation.sh
@@ -77,7 +77,7 @@ function validateCustomSSL() {
     export META_FILE="/etc/jelastic/metainf.conf"
     [ -f "/var/lib/jelastic/libs/envinfo.lib" ] && source "/var/lib/jelastic/libs/envinfo.lib";
 
-    [ -z "$ssl_module_inherit" ] && {
+    [[ -z "$ssl_module_inherit" && ! -f "/var/lib/jelastic/overrides/varnish_ssl.lib" ]] && {
         [[ "x${COMPUTE_TYPE}" != "xcartridge" || ! -f "${CARTRIDGE_HOME}/jelastic/scripts/ssl_manager.sh" ]] && { echo "Error: custom SSL is not available"; exit 1; }
     }
 


### PR DESCRIPTION
I made a fix for varnish containers where the custom-ssl validation fails but the status sent back to the user is that the installation succeeds even though nginx is not started and keys are not installed.

Not sure if this is completely correct handling of the issue but it works as a temporary workaround until something better is in place.