### PR TITLE
Increase domain limit for field validation

### DIFF
--- a/manifest.jps
+++ b/manifest.jps
@@ -51,7 +51,7 @@ settings:
   fields:
     - type: string
       name: customDomains
-      regex: "^([a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9]?(\\.[a-zA-Z0-9-]{1,}){1,6}[,|;]?){1,7}$"
+      regex: "^([a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9]?(\\.[a-zA-Z0-9-]{1,}){1,6}[,|;]?){1,100}$"
       caption: External Domain(s)
       required: false
     - type: string


### PR DESCRIPTION
Encountered a domain limit using this add-on and after some research it seems that it's only a field validation problem.

Currently you can only enter a maximum of seven domain names, but the Let's Encrypt actually allows [100 domains per certificate](https://letsencrypt.org/docs/rate-limits/).

I changed the regex validation to comply with it.