### PR TITLE
Remove nodejs from targetNodes

### DIFF
--- a/manifest.jps
+++ b/manifest.jps
@@ -38,7 +38,6 @@ targetNodes:
     - varnish-dockerized
     - payara
     - wildfly
-    - nodejs
     - apache-ruby
     - apache-python
     - nginxruby


### PR DESCRIPTION
nodejs nodes do not support custom SSL feature which is pre-requisite for Let's Encrypt.
fixes #217