### PR TITLE
add dockerengine to the manifest.jps

### DIFF
--- a/manifest.jps
+++ b/manifest.jps
@@ -48,6 +48,7 @@ targetNodes:
     - llsmp
     - jenkins
     - jenkins2
+    - dockerengine
 
 homepage: https://github.com/jelastic-jps/lets-encrypt
 baseUrl: https://raw.githubusercontent.com/jelastic-jps/lets-encrypt/master


### PR DESCRIPTION
if you uninstall letsencrypt from the docker engine then you can't reinstall it