### PR TITLE
regexp fixes

### DIFF
--- a/scripts/generate-ssl-cert.sh
+++ b/scripts/generate-ssl-cert.sh
@@ -124,7 +124,7 @@ do
     all_invalid_domains_errors+=$error";"
     all_invalid_domains+=$invalid_domain" "
 
-    domain=$(echo $domain | sed 's/^'${invalid_domain}'\s-d\s//' | sed 's/\s-d\s'${invalid_domain}'\s-d\s/ /' | sed 's/\s-d\s'${invalid_domain}'$//' | sed s/^'${invalid_domain}'$//')
+    domain=$(echo $domain | sed 's/^'${invalid_domain}'\s-d\s//' | sed 's/\s-d\s'${invalid_domain}'\s-d\s/ /' | sed 's/\s-d\s'${invalid_domain}'$//' | sed 's/^'${invalid_domain}'$//')
   }
   counter=$((counter + 1))
 done

--- a/scripts/generate-ssl-cert.sh
+++ b/scripts/generate-ssl-cert.sh
@@ -124,7 +124,7 @@ do
     all_invalid_domains_errors+=$error";"
     all_invalid_domains+=$invalid_domain" "
 
-    domain=$(echo $domain | sed 's/^'${invalid_domain}'\s-d\s//' | sed 's/\s-d\s'${invalid_domain}'\s-d\s/ /' | sed 's/\s-d\s'${invalid_domain}'$//' | sed 's/'${invalid_domain}'//')
+    domain=$(echo $domain | sed 's/^'${invalid_domain}'\s-d\s//' | sed 's/\s-d\s'${invalid_domain}'\s-d\s/ /' | sed 's/\s-d\s'${invalid_domain}'$//' | sed s/^'${invalid_domain}'$//')
   }
   counter=$((counter + 1))
 done

--- a/scripts/generate-ssl-cert.sh
+++ b/scripts/generate-ssl-cert.sh
@@ -124,7 +124,7 @@ do
     all_invalid_domains_errors+=$error";"
     all_invalid_domains+=$invalid_domain" "
 
-    domain=$(echo $domain | sed 's/^'${invalid_domain}'\s-d\s//' | sed 's/\s-d\s'${invalid_domain}'\s-d\s/ /' | sed 's/\s-d\s'${invalid_domain}'$//' | sed 's/^'${invalid_domain}'$//')
+    domain=$(echo $domain | sed 's/^'${invalid_domain}'\s-d\s//' | sed 's/\s-d\s'${invalid_domain}'\s-d\s/ -d /' | sed 's/\s-d\s'${invalid_domain}'$//' | sed 's/^'${invalid_domain}'$//')
   }
   counter=$((counter + 1))
 done

--- a/scripts/generate-ssl-cert.sh
+++ b/scripts/generate-ssl-cert.sh
@@ -124,7 +124,7 @@ do
     all_invalid_domains_errors+=$error";"
     all_invalid_domains+=$invalid_domain" "
 
-    domain=$(echo $domain | sed 's/^'${invalid_domain}'\s-d\s//' | sed 's/\s-d\s'${invalid_domain}'\s-d\s//' | sed 's/\s-d\s'${invalid_domain}'$//' | sed 's/'${invalid_domain}'//')
+    domain=$(echo $domain | sed 's/^'${invalid_domain}'\s-d\s//' | sed 's/\s-d\s'${invalid_domain}'\s-d\s/ /' | sed 's/\s-d\s'${invalid_domain}'$//' | sed 's/'${invalid_domain}'//')
   }
   counter=$((counter + 1))
 done


### PR DESCRIPTION
Hi,
Hope you are doing well!

@SlavaKatiukha 
It has been found issue while excluding invalid domain name the domains list.
For example domains list: 
www.testdomain.com testdomain.com www.testdomain.gr testdomain.gr nodexxxx-testdomain.j.scaleforce.net
had wrong excluding when domain testdomain.com is wrong on auth step.
We have fixed the issue in a customer env but this issue should be merged globally.
Thanks!